### PR TITLE
Fix startup errors for the relay

### DIFF
--- a/datastreamer/streamrelay.go
+++ b/datastreamer/streamrelay.go
@@ -50,19 +50,19 @@ func (r *StreamRelay) Start() error {
 	}
 	r.server.initEntry = r.client.Header.TotalEntries
 
+	// Start server side before exec command `CmdStart`
+	err = r.server.Start()
+	if err != nil {
+		log.Errorf("Error starting relay server: %v", err)
+		return err
+	}
+
 	// Sync with master server from latest received entry
 	r.client.FromEntry = r.server.GetHeader().TotalEntries
 	log.Infof("TotalEntries: RELAY %d of MASTER %d", r.client.FromEntry, r.server.initEntry)
 	err = r.client.ExecCommand(CmdStart)
 	if err != nil {
 		log.Errorf("Error executing start command: %v", err)
-		return err
-	}
-
-	// Start server side
-	err = r.server.Start()
-	if err != nil {
-		log.Errorf("Error starting relay server: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Closes #88 

### What does this PR do?

Fix startup errors for the relay when starting the relay.
Change the order in which `CmdStart` and `r.server.Start()` are executed.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->


### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @dpunish3r 