### PR TITLE
Add GHA to generate docker image for dsrelay

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -1,0 +1,31 @@
+on:
+    push:
+      branches:
+      - main
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+    
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+    
+            - name: Login to DockerHub
+              uses: docker/login-action@v3
+              with:
+                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+            - name: Build and push
+              id: docker_build
+              uses: docker/build-push-action@v5
+              with:
+                platforms: linux/amd64,linux/arm64
+                push: true
+                tags: |
+                    hermeznetwork/zkevm-dsrelay:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,30 @@
 # CONTAINER FOR BUILDING BINARY
-# FROM golang:1.21 AS build
+FROM golang:1.21 AS build
 
 # INSTALL DEPENDENCIES
-# RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
-# COPY go.mod go.sum /src/
-# RUN cd /src && go mod download
+RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
+COPY go.mod go.sum /src/
+RUN cd /src && go mod download
 
 # BUILD BINARY
-# COPY . /src
-# RUN cd /src && make build-dsrelay
+COPY relay /src/relay
+COPY datastreamer /src/datastreamer
+COPY log /src/log
+COPY Makefile version.go config/environments/testnet/config.toml /src/
+RUN cd /src && make build-dsrelay
+
 
 # CONTAINER FOR RUNNING BINARY
-# FROM alpine:3.18.4
-# COPY --from=build /src/dist/dsrelay /app/dsrelay
-# COPY --from=build /src/config/environments/testnet/config.toml /app/sample.config.toml
-# EXPOSE 7900
-# CMD ["/bin/sh", "-c", "/app/dsrelay"]
+FROM alpine:3.19.0
+
+COPY --from=build /src/dist/dsrelay /app/dsrelay
+COPY --from=build /src/config.toml /app/sample.config.toml
+
+ARG USER=dsrelay
+ENV HOME /home/$USER
+RUN adduser -D $USER
+USER $USER
+WORKDIR $HOME
+
+EXPOSE 7900
+CMD ["/bin/sh", "-c", "/app/dsrelay"]


### PR DESCRIPTION
Add required config to automatically generate a docker image with the app on main commits.